### PR TITLE
Fix wrong indent of encryption: key in config.yaml

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -126,7 +126,7 @@ bridge:
     #
     # Additionally, https://github.com/matrix-org/synapse/pull/5758 is required if using a normal
     # application service.
-        encryption:
+    encryption:
         # Allow encryption, work in group chat rooms with e2ee enabled
         allow: __ENCRYPTION__
         # Default to encryption, force-enable encryption in all portals the bridge creates


### PR DESCRIPTION
A typo in indentation caused parsing error on reading config file.

## Problem
Installer cannot parse config file because it's not well formed
```
2023-08-31 10:04:57,222: WARNING - ruamel.yaml.parser.ParserError: while parsing a block mapping
2023-08-31 10:04:57,223: WARNING -   in "/opt/yunohost/mautrix_googlechat/config.yaml", line 87, column 5
2023-08-31 10:04:57,223: WARNING - expected <block end>, but found '<block mapping start>'
2023-08-31 10:04:57,223: WARNING -   in "/opt/yunohost/mautrix_googlechat/config.yaml", line 129, column 9
```

## Solution
I fixed the typo

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

I did not run checks as the PR is trivial